### PR TITLE
Hide machine-specific paths inside gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -427,3 +427,5 @@ build/
 # pixi environments
 .pixi/*
 !.pixi/config.toml
+
+path_constants.yaml

--- a/include/Constants.h
+++ b/include/Constants.h
@@ -5,5 +5,6 @@ constexpr const char* appName = "Circus Simulator";
 constexpr unsigned initialWindowWidth = 800;
 constexpr unsigned initialWindowHeight = 600;
 constexpr const char* frameworkConfigPath = "resources/config/framework_config.yaml";
+constexpr const char* pathsConfigPath = "resources/config/path_constants.yaml";
 constexpr int frameworkCommunicationPort = 5555;
 }  // namespace spqr

--- a/include/RobotManager.h
+++ b/include/RobotManager.h
@@ -124,7 +124,7 @@ class RobotManager {
                 if (v2.starts_with("<")) {
                     int end = v2.find('>');
                     std::cout << "And the v2 is " << v2 << std::endl;
-                    std::string name = v2.substr(1, end-1);
+                    std::string name = v2.substr(1, end - 1);
                     std::cout << "And the name is " << name << std::endl;
 
                     if (!pathsRoot[name]) {
@@ -132,7 +132,7 @@ class RobotManager {
                     }
                     std::string name_str = pathsRoot[name].as<std::string>();
 
-                    v2.replace(0, end+1, name_str);
+                    v2.replace(0, end + 1, name_str);
                     std::cout << "And the NEW v2 is " << v2 << std::endl;
                 }
             } catch (const YAML::Exception& e) {

--- a/include/RobotManager.h
+++ b/include/RobotManager.h
@@ -121,7 +121,7 @@ class RobotManager {
             if (v2.starts_with("<")) {
                 int end = v2.find('>');
                 std::string name = v2.substr(1, end - 1);
-                
+
                 if (!pathsRoot[name]) {
                     throw std::runtime_error("Entry doesn't exist in path_constants: " + name);
                 }

--- a/include/RobotManager.h
+++ b/include/RobotManager.h
@@ -120,10 +120,6 @@ class RobotManager {
             } catch (const YAML::Exception& e) {
                 throw std::runtime_error("Volume entry must be a string: " + std::string(e.what()));
             }
-            if (v2.starts_with("<B>")) {
-                std::cout << pathsRoot["simbridge"].Type() << std::endl;
-                v2.replace(0, 3, pathsRoot["simbridge"].as<std::string>());
-            }
             try {
                 std::string appo;
                 if (v2.starts_with("<M>")) {

--- a/include/RobotManager.h
+++ b/include/RobotManager.h
@@ -83,17 +83,21 @@ class RobotManager {
         return nullptr;
     }
 
-    void startContainers() {
-        startCommunicationServer(frameworkCommunicationPort);
-
-        YAML::Node configRoot;
+    YAML::Node loadYamlFile(const char* path) {
         try {
-            configRoot = YAML::LoadFile(frameworkConfigPath);
+            return YAML::LoadFile(path);
         } catch (const YAML::BadFile& e) {
-            throw std::runtime_error("Failed to open YAML file: " + std::string(frameworkConfigPath));
+            throw std::runtime_error("Failed to open YAML file: " + std::string(path));
         } catch (const YAML::ParserException& e) {
             throw std::runtime_error("Failed to parse YAML file: " + std::string(e.what()));
         }
+    }
+
+    void startContainers() {
+        startCommunicationServer(frameworkCommunicationPort);
+
+        YAML::Node pathsRoot = loadYamlFile(pathsConfigPath);
+        YAML::Node configRoot = loadYamlFile(frameworkConfigPath);
 
         if (!configRoot["image"])
             throw std::runtime_error("Missing 'image' key in YAML file");
@@ -110,11 +114,38 @@ class RobotManager {
 
         std::vector<std::string> binds;
         for (const auto& v : configRoot["volumes"]) {
+            std::string v2;
             try {
-                binds.push_back(v.as<std::string>());
+                v2 = v.as<std::string>();
             } catch (const YAML::Exception& e) {
                 throw std::runtime_error("Volume entry must be a string: " + std::string(e.what()));
             }
+            if (v2.starts_with("<B>")) {
+                std::cout << pathsRoot["simbridge"].Type() << std::endl;
+                v2.replace(0, 3, pathsRoot["simbridge"].as<std::string>());
+            }
+            try {
+                std::string appo;
+                if (v2.starts_with("<M>")) {
+                    appo = pathsRoot["framework"].as<std::string>();
+                    v2.replace(0, 3, appo);
+                }
+                else if (v2.starts_with("<C>")) {
+                    appo = pathsRoot["circus"].as<std::string>();
+                    v2.replace(0, 3, appo);
+                }
+                else if (v2.starts_with("<S>")) {
+                    appo = pathsRoot["booster_robotics_sdk"].as<std::string>();
+                    v2.replace(0, 3, appo);
+                }
+                else if (v2.starts_with("<B>")) {
+                    appo = pathsRoot["simbridge"].as<std::string>();
+                    v2.replace(0, 3, appo);
+                }
+            } catch (const YAML::Exception& e) {
+                throw std::runtime_error("path_constants entries must be strings: " + std::string(e.what()));
+            }
+            binds.push_back(v2);
         }
 
         for (std::shared_ptr<Robot> r : robots_) {

--- a/include/RobotManager.h
+++ b/include/RobotManager.h
@@ -121,19 +121,19 @@ class RobotManager {
                 throw std::runtime_error("Volume entry must be a string: " + std::string(e.what()));
             }
             try {
-                std::string appo;
-                if (v2.starts_with("<M>")) {
-                    appo = pathsRoot["framework"].as<std::string>();
-                    v2.replace(0, 3, appo);
-                } else if (v2.starts_with("<C>")) {
-                    appo = pathsRoot["circus"].as<std::string>();
-                    v2.replace(0, 3, appo);
-                } else if (v2.starts_with("<S>")) {
-                    appo = pathsRoot["booster_robotics_sdk"].as<std::string>();
-                    v2.replace(0, 3, appo);
-                } else if (v2.starts_with("<B>")) {
-                    appo = pathsRoot["simbridge"].as<std::string>();
-                    v2.replace(0, 3, appo);
+                if (v2.starts_with("<")) {
+                    int end = v2.find('>');
+                    std::cout << "And the v2 is " << v2 << std::endl;
+                    std::string name = v2.substr(1, end-1);
+                    std::cout << "And the name is " << name << std::endl;
+
+                    if (!pathsRoot[name]) {
+                        throw std::runtime_error("Entry doesn't exist in path_constants: " + name);
+                    }
+                    std::string name_str = pathsRoot[name].as<std::string>();
+
+                    v2.replace(0, end+1, name_str);
+                    std::cout << "And the NEW v2 is " << v2 << std::endl;
                 }
             } catch (const YAML::Exception& e) {
                 throw std::runtime_error("path_constants entries must be strings: " + std::string(e.what()));

--- a/include/RobotManager.h
+++ b/include/RobotManager.h
@@ -129,16 +129,13 @@ class RobotManager {
                 if (v2.starts_with("<M>")) {
                     appo = pathsRoot["framework"].as<std::string>();
                     v2.replace(0, 3, appo);
-                }
-                else if (v2.starts_with("<C>")) {
+                } else if (v2.starts_with("<C>")) {
                     appo = pathsRoot["circus"].as<std::string>();
                     v2.replace(0, 3, appo);
-                }
-                else if (v2.starts_with("<S>")) {
+                } else if (v2.starts_with("<S>")) {
                     appo = pathsRoot["booster_robotics_sdk"].as<std::string>();
                     v2.replace(0, 3, appo);
-                }
-                else if (v2.starts_with("<B>")) {
+                } else if (v2.starts_with("<B>")) {
                     appo = pathsRoot["simbridge"].as<std::string>();
                     v2.replace(0, 3, appo);
                 }

--- a/include/RobotManager.h
+++ b/include/RobotManager.h
@@ -93,6 +93,14 @@ class RobotManager {
         }
     }
 
+    std::string tryString(YAML::Node node, std::string message) {
+        try {
+            return node.as<std::string>();
+        } catch (const YAML::Exception& e) {
+            throw std::runtime_error(message + std::string(e.what()));
+        }
+    }
+
     void startContainers() {
         startCommunicationServer(frameworkCommunicationPort);
 
@@ -102,41 +110,24 @@ class RobotManager {
         if (!configRoot["image"])
             throw std::runtime_error("Missing 'image' key in YAML file");
 
-        std::string image;
-        try {
-            image = configRoot["image"].as<std::string>();
-        } catch (const YAML::Exception& e) {
-            throw std::runtime_error("'image' must be a string: " + std::string(e.what()));
-        }
+        std::string image = tryString(configRoot["image"], "'image' must be a string: ");
 
         if (!configRoot["volumes"] || !configRoot["volumes"].IsSequence())
             throw std::runtime_error("'volumes' key missing or not a sequence");
 
         std::vector<std::string> binds;
         for (const auto& v : configRoot["volumes"]) {
-            std::string v2;
-            try {
-                v2 = v.as<std::string>();
-            } catch (const YAML::Exception& e) {
-                throw std::runtime_error("Volume entry must be a string: " + std::string(e.what()));
-            }
-            try {
-                if (v2.starts_with("<")) {
-                    int end = v2.find('>');
-                    std::cout << "And the v2 is " << v2 << std::endl;
-                    std::string name = v2.substr(1, end - 1);
-                    std::cout << "And the name is " << name << std::endl;
-
-                    if (!pathsRoot[name]) {
-                        throw std::runtime_error("Entry doesn't exist in path_constants: " + name);
-                    }
-                    std::string name_str = pathsRoot[name].as<std::string>();
-
-                    v2.replace(0, end + 1, name_str);
-                    std::cout << "And the NEW v2 is " << v2 << std::endl;
+            std::string v2 = tryString(v, "Volume entry must be a string: ");
+            if (v2.starts_with("<")) {
+                int end = v2.find('>');
+                std::string name = v2.substr(1, end - 1);
+                
+                if (!pathsRoot[name]) {
+                    throw std::runtime_error("Entry doesn't exist in path_constants: " + name);
                 }
-            } catch (const YAML::Exception& e) {
-                throw std::runtime_error("path_constants entries must be strings: " + std::string(e.what()));
+
+                std::string name_str = tryString(pathsRoot[name], "path_constants entries must be strings: ");
+                v2.replace(0, end + 1, name_str);
             }
             binds.push_back(v2);
         }

--- a/resources/config/framework_config.yaml
+++ b/resources/config/framework_config.yaml
@@ -1,12 +1,7 @@
-# path_constant replacements legend:
-# <M> framework
-# <C> circus
-# <S> booster_robotics_sdk
-# <B> simbridge
-# strictly NO FINAL SLASH in the path_constants paths.
+# advice: NO FINAL SLASH in the path_constants paths.
 
 image: spqr:booster
 volumes:
-  - "<B>/tools/booster_motion:/app/booster_motion"
-  - "<B>/build:/app/bridge"
-  - "<S>/build:/app/sdk"
+  - "<simbridge>/tools/booster_motion:/app/booster_motion"
+  - "<simbridge>/build:/app/bridge"
+  - "<booster_robotics_sdk>/build:/app/sdk"

--- a/resources/config/framework_config.yaml
+++ b/resources/config/framework_config.yaml
@@ -1,4 +1,12 @@
+# path_constant replacements legend:
+# <M> framework
+# <C> circus
+# <S> booster_robotics_sdk
+# <B> simbridge
+# strictly NO FINAL SLASH in the path_constants paths.
+
 image: spqr:booster
 volumes:
-  - "/home/flavio/Scrivania/RoboCup/simbridge/tools/booster_motion:/app/booster_motion"
-  - "/home/flavio/Scrivania/RoboCup/simbridge/build:/app/bridge"
+  - "<B>/tools/booster_motion:/app/booster_motion"
+  - "<B>/build:/app/bridge"
+  - "<S>/build:/app/sdk"


### PR DESCRIPTION
Ognuno deve crearsi il proprio file `resources/config/path_constants.yaml` e farlo tipo così:
```yaml
framework: /home/.../spqrbooster2026
circus: /home/.../circus
booster_robotics_sdk: /home/.../booster_robotics_sdk
simbridge: /home/.../simbridge
```
Perché non ne potevo più di dover stashare framework_config ogni volta che Flavio cambiava qualcosa.
Vi piace?