### PR TITLE
Add clean-containers cmd

### DIFF
--- a/clean-containers.sh
+++ b/clean-containers.sh
@@ -1,0 +1,18 @@
+# https://stackoverflow.com/questions/56998486/stop-docker-containers-with-name-matching-a-pattern
+# ...and some help from Gemini for the ifs
+
+RUNNING_IDS=$(docker ps --filter name="CIRCUS_*" --filter status=running -aq)
+if [ -n "$RUNNING_IDS" ]; then
+    echo "Stopping circus containers"
+    docker stop $RUNNING_IDS
+else
+    echo "Nothing to stop"
+fi
+
+EXITED_IDS=$(docker ps --filter name="CIRCUS_*" --filter status=exited -aq)
+if [ -n "$EXITED_IDS" ]; then
+    echo "Removing circus containers"
+    docker rm $EXITED_IDS
+else
+    echo "Nothing to remove"
+fi

--- a/clean-containers.sh
+++ b/clean-containers.sh
@@ -9,7 +9,7 @@ else
     echo "Nothing to stop"
 fi
 
-EXITED_IDS=$(docker ps --filter name="CIRCUS_*" --filter status=exited -aq)
+EXITED_IDS=$(docker ps --filter name="CIRCUS_*" -aq)
 if [ -n "$EXITED_IDS" ]; then
     echo "Removing circus containers"
     docker rm $EXITED_IDS

--- a/include/RobotManager.h
+++ b/include/RobotManager.h
@@ -115,7 +115,7 @@ class RobotManager {
             }
 
             for (std::shared_ptr<Robot> r : robots_) {
-                r->container = std::make_unique<Container>(r->name + "_container");
+                r->container = std::make_unique<Container>("CIRCUS_" + r->name + "_container");
                 r->container->create(r->name, image, binds);
                 r->container->start();
             }

--- a/pixi.toml
+++ b/pixi.toml
@@ -42,6 +42,7 @@ libegl-devel = "==1.7.0"
 
 [tasks]
 test = "python -c 'import circuspy; circuspy.test()'"
+clean-containers = "bash clean-containers.sh"
 
 [activation]
 # Add DYLD_LIBRARY_PATH on macOS so the MuJoCo dylib is found when running binaries directly


### PR DESCRIPTION
Aggiunge un comando `pixi run clean-containers` per stoppare e rimuovere tutti i container, ad esempio a seguito di un crash.

Per farlo funzionare al meglio, ho fatto aggiungere un prefisso "CIRCUS_" al nome dei container, da quello che vedo non si dovrebbe rompere nulla in Circus. Ma se avete script vostri dovrete aggiornarli.

Sono aperto a suggerimenti per un nome più corto per il comando.