### PR TITLE
Camera depth

### DIFF
--- a/include/frontend/tools_panel/ToolsPanel.h
+++ b/include/frontend/tools_panel/ToolsPanel.h
@@ -212,8 +212,7 @@ class ToolsPanel : public QWidget {
         QMap<QString, ToolType> getStreams() {
             std::vector<std::string> available_streams = {
                 "position",      "orientation",         "joints_position",  "joints_velocity", "joints_acceleration",
-                "joints_torque", "linear_acceleration", "angular_velocity", "rgb_left_camera", "rgb_right_camera",
-                "terminal",
+                "joints_torque", "linear_acceleration", "angular_velocity", "rgb_camera",      "terminal",
             };
 
             QMap<QString, ToolType> streams;
@@ -229,7 +228,7 @@ class ToolsPanel : public QWidget {
                             || stream == "joints_acceleration" || stream == "joints_torque" || stream == "linear_acceleration"
                             || stream == "angular_velocity") {
                             streams.insert(full_stream_name, ToolType::PLOT);
-                        } else if (stream == "rgb_left_camera" || stream == "rgb_right_camera") {
+                        } else if (stream == "rgb_camera") {
                             streams.insert(full_stream_name, ToolType::IMAGE);
                         } else if (stream == "terminal") {
                             streams.insert(full_stream_name, ToolType::TERMINAL);

--- a/include/frontend/tools_panel/ToolsPanel.h
+++ b/include/frontend/tools_panel/ToolsPanel.h
@@ -212,7 +212,8 @@ class ToolsPanel : public QWidget {
         QMap<QString, ToolType> getStreams() {
             std::vector<std::string> available_streams = {
                 "position",      "orientation",         "joints_position",  "joints_velocity", "joints_acceleration",
-                "joints_torque", "linear_acceleration", "angular_velocity", "rgb_camera",      "terminal",
+                "joints_torque", "linear_acceleration", "angular_velocity", "rgb_camera",      "depth_camera",
+                "terminal",
             };
 
             QMap<QString, ToolType> streams;
@@ -228,7 +229,7 @@ class ToolsPanel : public QWidget {
                             || stream == "joints_acceleration" || stream == "joints_torque" || stream == "linear_acceleration"
                             || stream == "angular_velocity") {
                             streams.insert(full_stream_name, ToolType::PLOT);
-                        } else if (stream == "rgb_camera") {
+                        } else if (stream == "rgb_camera" || stream == "depth_camera") {
                             streams.insert(full_stream_name, ToolType::IMAGE);
                         } else if (stream == "terminal") {
                             streams.insert(full_stream_name, ToolType::TERMINAL);

--- a/include/frontend/tools_panel/ToolsPanelGrid.h
+++ b/include/frontend/tools_panel/ToolsPanelGrid.h
@@ -21,7 +21,7 @@
 
 #include "MujocoContext.h"
 #include "robots/Robot.h"
-#include "sensors/Camera.h"
+#include "sensors/CameraRGB.h"
 #include "sensors/Imu.h"
 #include "sensors/Joint.h"
 #include "sensors/Pose.h"
@@ -622,17 +622,16 @@ class ToolsPanelGrid : public QWidget {
                                 Image* imageTool = dynamic_cast<Image*>(tool);
 
                                 // Add image data based on sensor type
-                                if (sensorType == "rgb_left_camera" || sensorType == "rgb_right_camera") {
-                                    std::string cameraName = (sensorType == "rgb_left_camera") ? "rgb_left_camera" : "rgb_right_camera";
-                                    auto it = sensors.find(cameraName);
+                                if (sensorType == "rgb_camera") {
+                                    auto it = sensors.find("rgb_camera");
 
                                     if (it != sensors.end()) {
-                                        Camera* camera = dynamic_cast<Camera*>(it->second);
+                                        CameraRGB* rgbCamera = dynamic_cast<CameraRGB*>(it->second);
 
-                                        if (camera) {
-                                            const std::vector<uint8_t>& imageData = camera->getImage();
-                                            int width = camera->getWidth();
-                                            int height = camera->getHeight();
+                                        if (rgbCamera) {
+                                            const std::vector<uint8_t>& imageData = rgbCamera->getImage();
+                                            int width = rgbCamera->getWidth();
+                                            int height = rgbCamera->getHeight();
 
                                             if (!imageData.empty() && width > 0 && height > 0) {
                                                 imageTool->setImage(imageData.data(), width, height, 3);

--- a/include/frontend/tools_panel/ToolsPanelGrid.h
+++ b/include/frontend/tools_panel/ToolsPanelGrid.h
@@ -21,6 +21,7 @@
 
 #include "MujocoContext.h"
 #include "robots/Robot.h"
+#include "sensors/CameraDepth.h"
 #include "sensors/CameraRGB.h"
 #include "sensors/Imu.h"
 #include "sensors/Joint.h"
@@ -635,6 +636,30 @@ class ToolsPanelGrid : public QWidget {
 
                                             if (!imageData.empty() && width > 0 && height > 0) {
                                                 imageTool->setImage(imageData.data(), width, height, 3);
+                                            } else {
+                                            }
+                                        }
+                                    }
+                                }
+
+                                if (sensorType == "depth_camera") {
+                                    auto it = sensors.find("depth_camera");
+
+                                    if (it != sensors.end()) {
+                                        CameraDepth* depthCamera = dynamic_cast<CameraDepth*>(it->second);
+
+                                        if (depthCamera) {
+                                            // const std::vector<float>& depthData = depthCamera->getDepthNormalized();
+                                            const std::vector<uint16_t>& depthData = depthCamera->getDepth();
+                                            int width = depthCamera->getWidth();
+                                            int height = depthCamera->getHeight();
+
+                                            if (!depthData.empty() && width > 0 && height > 0) {
+                                                std::vector<uint8_t> depthImage(depthData.size());
+                                                for (size_t i = 0; i < depthData.size(); ++i) {
+                                                    depthImage[i] = static_cast<uint8_t>(depthData[i] / 256);  // Scale 16-bit to 8-bit
+                                                }
+                                                imageTool->setImage(depthImage.data(), width, height, 1);
                                             } else {
                                             }
                                         }

--- a/include/frontend/tools_panel/tools/Image.h
+++ b/include/frontend/tools_panel/tools/Image.h
@@ -55,7 +55,9 @@ class ImageDisplay : public QWidget {
             }
 
             QImage::Format format;
-            if (channels == 3) {
+            if (channels == 1) {
+                format = QImage::Format_Grayscale8;
+            } else if (channels == 3) {
                 format = QImage::Format_RGB888;
             } else if (channels == 4) {
                 format = QImage::Format_RGBA8888;

--- a/include/robots/BoosterK1.h
+++ b/include/robots/BoosterK1.h
@@ -21,6 +21,7 @@
 #include "sensors/Imu.h"
 #include "sensors/Joint.h"
 #include "sensors/Pose.h"
+#include "sensors/CameraDepth.h"
 
 #define MAX_MSG_SIZE 1048576  // 1MB
 namespace spqr {
@@ -33,6 +34,7 @@ class BoosterK1 : public Robot {
         Imu* imu;
         Joints* joints = nullptr;
         std::array<Camera*, 2> cameras = {};
+        CameraDepth* cameraDepth;
 
         BoosterK1(const std::string& name, const std::string& type, uint8_t number, const Eigen::Vector3d& initPosition,
                   const Eigen::Vector3d& initOrientation, const std::tuple<int, int, int> color, const std::shared_ptr<Team>& team)
@@ -66,6 +68,7 @@ class BoosterK1 : public Robot {
             joints = new Joints(mujCtx->model, mujCtx->data, joint_map);
             cameras[0] = new Camera(mujCtx, (name + "_left_cam").c_str());
             cameras[1] = new Camera(mujCtx, (name + "_right_cam").c_str());
+            cameraDepth = new CameraDepth(mujCtx, (name + "_depth_cam").c_str());
         }
 
         void receiveMessage(const std::map<std::string, msgpack::object>& message) override {
@@ -98,6 +101,7 @@ class BoosterK1 : public Robot {
             sensors["joints"] = joints;
             sensors["rgb_left_camera"] = cameras[0];
             sensors["rgb_right_camera"] = cameras[1];
+            sensors["depth_camera"] = cameraDepth;
             return sensors;
         }
 
@@ -107,6 +111,7 @@ class BoosterK1 : public Robot {
             joints->update();
             cameras[0]->update();
             cameras[1]->update();
+            cameraDepth->update();
         }
 
         ~BoosterK1() = default;

--- a/include/robots/BoosterK1.h
+++ b/include/robots/BoosterK1.h
@@ -17,11 +17,11 @@
 
 #include "MujocoContext.h"
 #include "robots/Robot.h"
-#include "sensors/Camera.h"
+#include "sensors/CameraDepth.h"
+#include "sensors/CameraRGB.h"
 #include "sensors/Imu.h"
 #include "sensors/Joint.h"
 #include "sensors/Pose.h"
-#include "sensors/CameraDepth.h"
 
 #define MAX_MSG_SIZE 1048576  // 1MB
 namespace spqr {
@@ -33,8 +33,8 @@ class BoosterK1 : public Robot {
         Pose* pose = nullptr;
         Imu* imu;
         Joints* joints = nullptr;
-        std::array<Camera*, 2> cameras = {};
-        CameraDepth* cameraDepth;
+        CameraRGB* rgbCamera;
+        CameraDepth* depthCamera;
 
         BoosterK1(const std::string& name, const std::string& type, uint8_t number, const Eigen::Vector3d& initPosition,
                   const Eigen::Vector3d& initOrientation, const std::tuple<int, int, int> color, const std::shared_ptr<Team>& team)
@@ -66,9 +66,8 @@ class BoosterK1 : public Robot {
             pose = new Pose(mujCtx->model, mujCtx->data, (name + "_position").c_str(), (name + "_orientation").c_str());
             imu = new Imu(mujCtx->model, mujCtx->data, (name + "_linear-acceleration").c_str(), (name + "_angular-velocity").c_str());
             joints = new Joints(mujCtx->model, mujCtx->data, joint_map);
-            cameras[0] = new Camera(mujCtx, (name + "_left_cam").c_str());
-            cameras[1] = new Camera(mujCtx, (name + "_right_cam").c_str());
-            cameraDepth = new CameraDepth(mujCtx, (name + "_depth_cam").c_str());
+            rgbCamera = new CameraRGB(mujCtx, (name + "_rgb_cam").c_str());
+            depthCamera = new CameraDepth(mujCtx, (name + "_depth_cam").c_str());
         }
 
         void receiveMessage(const std::map<std::string, msgpack::object>& message) override {
@@ -99,9 +98,8 @@ class BoosterK1 : public Robot {
             sensors["pose"] = pose;
             sensors["imu"] = imu;
             sensors["joints"] = joints;
-            sensors["rgb_left_camera"] = cameras[0];
-            sensors["rgb_right_camera"] = cameras[1];
-            sensors["depth_camera"] = cameraDepth;
+            sensors["rgb_camera"] = rgbCamera;
+            sensors["depth_camera"] = depthCamera;
             return sensors;
         }
 
@@ -109,9 +107,8 @@ class BoosterK1 : public Robot {
             pose->update();
             imu->update();
             joints->update();
-            cameras[0]->update();
-            cameras[1]->update();
-            cameraDepth->update();
+            rgbCamera->update();
+            depthCamera->update();
         }
 
         ~BoosterK1() = default;

--- a/include/robots/BoosterT1.h
+++ b/include/robots/BoosterT1.h
@@ -21,6 +21,7 @@
 #include "sensors/Imu.h"
 #include "sensors/Joint.h"
 #include "sensors/Pose.h"
+#include "sensors/CameraDepth.h"
 
 #define MAX_MSG_SIZE 1048576  // 1MB
 namespace spqr {
@@ -33,6 +34,7 @@ class BoosterT1 : public Robot {
         Imu* imu = nullptr;
         Joints* joints = nullptr;
         std::array<Camera*, 2> cameras = {};
+        CameraDepth* cameraDepth;
 
         BoosterT1(const std::string& name, const std::string& type, uint8_t number, const Eigen::Vector3d& initPosition,
                   const Eigen::Vector3d& initOrientation, const std::tuple<int, int, int> color, const std::shared_ptr<Team>& team)
@@ -92,6 +94,7 @@ class BoosterT1 : public Robot {
 
             cameras[0] = new Camera(mujCtx, (name + "_left_cam").c_str());
             cameras[1] = new Camera(mujCtx, (name + "_right_cam").c_str());
+            cameraDepth = new CameraDepth(mujCtx, (name + "_depth_cam").c_str());
         }
 
         void receiveMessage(const std::map<std::string, msgpack::object>& message) override {
@@ -135,6 +138,7 @@ class BoosterT1 : public Robot {
             sensors["joints"] = joints;
             sensors["rgb_left_camera"] = cameras[0];
             sensors["rgb_right_camera"] = cameras[1];
+            sensors["depth_camera"] = cameraDepth;
             return sensors;
         }
 
@@ -144,6 +148,7 @@ class BoosterT1 : public Robot {
             joints->update();
             cameras[0]->update();
             cameras[1]->update();
+            cameraDepth->update();
         }
 
         ~BoosterT1() = default;

--- a/include/robots/BoosterT1.h
+++ b/include/robots/BoosterT1.h
@@ -17,11 +17,11 @@
 
 #include "MujocoContext.h"
 #include "robots/Robot.h"
-#include "sensors/Camera.h"
+#include "sensors/CameraDepth.h"
+#include "sensors/CameraRGB.h"
 #include "sensors/Imu.h"
 #include "sensors/Joint.h"
 #include "sensors/Pose.h"
-#include "sensors/CameraDepth.h"
 
 #define MAX_MSG_SIZE 1048576  // 1MB
 namespace spqr {
@@ -33,8 +33,8 @@ class BoosterT1 : public Robot {
         Pose* pose = nullptr;
         Imu* imu = nullptr;
         Joints* joints = nullptr;
-        std::array<Camera*, 2> cameras = {};
-        CameraDepth* cameraDepth;
+        CameraRGB* rgbCamera;
+        CameraDepth* depthCamera;
 
         BoosterT1(const std::string& name, const std::string& type, uint8_t number, const Eigen::Vector3d& initPosition,
                   const Eigen::Vector3d& initOrientation, const std::tuple<int, int, int> color, const std::shared_ptr<Team>& team)
@@ -92,9 +92,8 @@ class BoosterT1 : public Robot {
                                   {JointValue::ANKLE_RIGHT_PITCH, 0},
                                   {JointValue::ANKLE_RIGHT_ROLL, 0}});
 
-            cameras[0] = new Camera(mujCtx, (name + "_left_cam").c_str());
-            cameras[1] = new Camera(mujCtx, (name + "_right_cam").c_str());
-            cameraDepth = new CameraDepth(mujCtx, (name + "_depth_cam").c_str());
+            rgbCamera = new CameraRGB(mujCtx, (name + "_rgb_cam").c_str());
+            depthCamera = new CameraDepth(mujCtx, (name + "_depth_cam").c_str());
         }
 
         void receiveMessage(const std::map<std::string, msgpack::object>& message) override {
@@ -136,9 +135,8 @@ class BoosterT1 : public Robot {
             sensors["pose"] = pose;
             sensors["imu"] = imu;
             sensors["joints"] = joints;
-            sensors["rgb_left_camera"] = cameras[0];
-            sensors["rgb_right_camera"] = cameras[1];
-            sensors["depth_camera"] = cameraDepth;
+            sensors["rgb_camera"] = rgbCamera;
+            sensors["depth_camera"] = depthCamera;
             return sensors;
         }
 
@@ -146,9 +144,8 @@ class BoosterT1 : public Robot {
             pose->update();
             imu->update();
             joints->update();
-            cameras[0]->update();
-            cameras[1]->update();
-            cameraDepth->update();
+            rgbCamera->update();
+            depthCamera->update();
         }
 
         ~BoosterT1() = default;

--- a/include/robots/Robot.h
+++ b/include/robots/Robot.h
@@ -8,7 +8,6 @@
 #include <yaml-cpp/yaml.h>
 
 #include <Eigen/Eigen>
-#include <iostream>
 #include <memory>
 #include <msgpack.hpp>
 #include <msgpack/v3/object_fwd_decl.hpp>

--- a/include/sensors/CameraDepth.h
+++ b/include/sensors/CameraDepth.h
@@ -5,7 +5,6 @@
 
 #include <QImage>
 #include <QOpenGLFunctions>
-#include <cstring>
 #include <msgpack.hpp>
 #include <string>
 #include <vector>
@@ -27,7 +26,7 @@ class CameraDepth : public Sensor {
             w = mujContext->model->cam_resolution[2 * cam.fixedcamid + 0];
             h = mujContext->model->cam_resolution[2 * cam.fixedcamid + 1];
             fovy_deg = mujContext->model->cam_fovy[cam.fixedcamid];
-            
+
             depthNormalized.resize(w * h);
             depth.resize(w * h);
         }
@@ -79,15 +78,15 @@ class CameraDepth : public Sensor {
             std::vector<float> tempDepth(viewWidth * viewHeight);
             mjr_readPixels(nullptr, tempDepth.data(), viewport, &mujContext->ctx);
 
-            float znear = mujContext->model->vis.map.znear; // 0.0001
-            float zfar = mujContext->model->vis.map.zfar; // 50.0
-            float max_u16 = static_cast<float>(std::numeric_limits<uint16_t>::max() );
+            float znear = mujContext->model->vis.map.znear;  // 0.0001
+            float zfar = mujContext->model->vis.map.zfar;    // 50.0
+            float max_u16 = static_cast<float>(std::numeric_limits<uint16_t>::max());
 
             // Process depth to match camera resolution
             for (int y = 0; y < h; y++) {
                 int srcRow = (h - 1 - y) * w;  // flip y-axes
                 int dstRow = y * w;
-                for (int x=0; x < w; x++) {
+                for (int x = 0; x < w; x++) {
                     float z_raw = tempDepth[srcRow + x];
                     float z_converted = (znear * zfar) / (zfar - z_raw * (zfar - znear));
                     depthNormalized[dstRow + x] = z_converted;

--- a/include/sensors/CameraDepth.h
+++ b/include/sensors/CameraDepth.h
@@ -1,0 +1,151 @@
+#pragma once
+#include <mujoco/mjrender.h>
+#include <mujoco/mjvisualize.h>
+#include <mujoco/mujoco.h>
+
+#include <QImage>
+#include <QOpenGLFunctions>
+#include <cstring>
+#include <msgpack.hpp>
+#include <string>
+#include <vector>
+
+#include "MujocoContext.h"
+#include "sensors/Sensor.h"
+
+namespace spqr {
+
+class CameraDepth : public Sensor {
+    public:
+        CameraDepth(MujocoContext* mujContext, const char* cameraName) : mujContext(mujContext), cameraName_(cameraName) {
+            cam.type = mjCAMERA_FIXED;
+            cam.fixedcamid = mj_name2id(mujContext->model, mjOBJ_CAMERA, cameraName);
+
+            if (cam.fixedcamid < 0)
+                throw std::runtime_error(std::string("Camera not found: ") + cameraName);
+
+            w = mujContext->model->cam_resolution[2 * cam.fixedcamid + 0];
+            h = mujContext->model->cam_resolution[2 * cam.fixedcamid + 1];
+            fovy_deg = mujContext->model->cam_fovy[cam.fixedcamid];
+            
+            depthNormalized.resize(w * h);
+            depth.resize(w * h);
+        }
+
+        void doUpdate() override {
+            // Camera rendering must happen in the OpenGL thread (paintGL), not here
+            // This method is called from the simulation thread which has no GL context
+        }
+
+        void render() {
+            // Create temporary scene for this camera to avoid modifying the main scene
+            mjvScene tempScene;
+            mjv_defaultScene(&tempScene);
+            mjv_makeScene(mujContext->model, &tempScene, 1000);
+
+            // Get offscreen buffer dimensions
+            int offWidth = mujContext->ctx.offWidth;
+            int offHeight = mujContext->ctx.offHeight;
+
+            // Calculate viewport to fit camera aspect ratio within offscreen buffer
+            float camAspect = (float)w / (float)h;
+            float bufAspect = (float)offWidth / (float)offHeight;
+
+            int viewWidth, viewHeight;
+            if (camAspect > bufAspect) {
+                // Camera is wider - fit to width
+                viewWidth = offWidth;
+                viewHeight = (int)(offWidth / camAspect);
+            } else {
+                // Camera is taller - fit to height
+                viewHeight = offHeight;
+                viewWidth = (int)(offHeight * camAspect);
+            }
+
+            mjrRect viewport = {0, 0, viewWidth, viewHeight};
+            mjr_setBuffer(mjFB_OFFSCREEN, &mujContext->ctx);
+
+            // Create a copy of visualization options to disable number geoms (group 4) for robot cameras
+            mjvOption tempOpt = mujContext->opt;
+            tempOpt.geomgroup[4] = 0;  // Hide group 4 (robot number labels) from robot cameras
+
+            // Update scene with this camera's viewpoint
+            mjv_updateScene(mujContext->model, mujContext->data, &tempOpt, nullptr, &cam, mjCAT_ALL, &tempScene);
+
+            // Render the scene
+            mjr_render(viewport, &tempScene, &mujContext->ctx);
+
+            // Read pixels and resize to camera resolution
+            std::vector<float> tempDepth(viewWidth * viewHeight);
+            mjr_readPixels(nullptr, tempDepth.data(), viewport, &mujContext->ctx);
+
+            float znear = mujContext->model->vis.map.znear; // 0.0001
+            float zfar = mujContext->model->vis.map.zfar; // 50.0
+            float max_u16 = static_cast<float>(std::numeric_limits<uint16_t>::max() );
+
+            // Process depth to match camera resolution
+            for (int y = 0; y < h; y++) {
+                int srcRow = (h - 1 - y) * w;  // flip y-axes
+                int dstRow = y * w;
+                for (int x=0; x < w; x++) {
+                    float z_raw = tempDepth[srcRow + x];
+                    float z_converted = (znear * zfar) / (zfar - z_raw * (zfar - znear));
+                    depthNormalized[dstRow + x] = z_converted;
+
+                    float clampedDepth = std::min(z_converted / 1.0f, 1.0f);
+                    depth[dstRow + x] = static_cast<uint16_t>(clampedDepth * max_u16);
+                }
+            }
+
+            // Restore window buffer
+            mjr_setBuffer(mjFB_WINDOW, &mujContext->ctx);
+
+            // Free temporary scene
+            mjv_freeScene(&tempScene);
+        }
+
+        void saveImage(const std::string& filename) const {
+            QImage qimg(reinterpret_cast<const uchar*>(depth.data()), w, h, w * 2, QImage::Format_Grayscale16);
+            qimg.save(QString::fromStdString(filename));
+        }
+
+        const mjvCamera& getCamera() const {
+            return cam;
+        }
+
+        const std::vector<float>& getDepthNormalized() const {
+            return depthNormalized;
+        }
+
+        const std::vector<uint16_t>& getDepth() const {
+            return depth;
+        }
+
+        int getWidth() const {
+            return w;
+        }
+
+        int getHeight() const {
+            return h;
+        }
+
+        double getFovyDeg() const {
+            return fovy_deg;
+        }
+
+        msgpack::object doSerialize(msgpack::zone& z) override {
+            std::vector<uint16_t> img_copy(depth.begin(), depth.end());
+            return msgpack::object(img_copy, z);
+        }
+
+    private:
+        int w, h;
+        double fovy_deg;
+        MujocoContext* mujContext;
+        std::vector<float> depthNormalized;
+        std::vector<uint16_t> depth;
+        mjvCamera cam{};
+        std::string cameraName_;
+};
+
+}  // namespace spqr

--- a/include/sensors/CameraRGB.h
+++ b/include/sensors/CameraRGB.h
@@ -15,9 +15,9 @@
 
 namespace spqr {
 
-class Camera : public Sensor {
+class CameraRGB : public Sensor {
     public:
-        Camera(MujocoContext* mujContext, const char* cameraName) : mujContext(mujContext), cameraName_(cameraName) {
+        CameraRGB(MujocoContext* mujContext, const char* cameraName) : mujContext(mujContext), cameraName_(cameraName) {
             cam.type = mjCAMERA_FIXED;
             cam.fixedcamid = mj_name2id(mujContext->model, mjOBJ_CAMERA, cameraName);
 

--- a/resources/robots/Booster-K1/instance.xml
+++ b/resources/robots/Booster-K1/instance.xml
@@ -44,6 +44,8 @@
                     <camera name="left_cam" pos="0.05 0.06 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="1920 1080"/>
                     <site name="head_right_cam_site" pos="0.05 -0.06 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
                     <camera name="right_cam" pos="0.05 -0.06 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="1920 1080"/>
+                    <site name="head_depth_cam_site" pos="0.05 0 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
+                    <camera name="depth_cam" pos="0.05 0 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="1920 1080"/>
                 </body>
             </body>
             <body name="Left_Arm_1" pos="0 0.077 0.1845">

--- a/resources/robots/Booster-K1/instance.xml
+++ b/resources/robots/Booster-K1/instance.xml
@@ -40,12 +40,12 @@
                         material="black" mesh="Booster-K1_Head_2" />
                     <geom type="mesh" material="black" mesh="Booster-K1_Head_2" />
 
-                    <site name="head_left_cam_site" pos="0.05 0.06 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
-                    <camera name="left_cam" pos="0.05 0.06 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="1920 1080"/>
-                    <site name="head_right_cam_site" pos="0.05 -0.06 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
-                    <camera name="right_cam" pos="0.05 -0.06 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="1920 1080"/>
-                    <site name="head_depth_cam_site" pos="0.05 0 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
-                    <camera name="depth_cam" pos="0.05 0 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="1920 1080"/>
+                    <site name="head_rgb_cam_site" pos="0.05 0.0 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
+                    <camera name="rgb_cam" pos="0.05 0.06 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="640 480"/>
+
+                    <site name="head_depth_cam_site" pos="0.05 0.0 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
+                    <camera name="depth_cam" pos="0.05 0 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="640 480"/>
+
                 </body>
             </body>
             <body name="Left_Arm_1" pos="0 0.077 0.1845">

--- a/resources/robots/Booster-T1/instance.xml
+++ b/resources/robots/Booster-T1/instance.xml
@@ -33,12 +33,14 @@
                     <geom class="visual" material="black" mesh="Booster-T1_H2"/>
                     <geom size="0.08" pos="0.01 0 0.11" class="collision" name="head"/>
 
-                    <site name="head_left_cam_site" pos="0.05 0.06 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
-                    <camera name="left_cam" pos="0.05 0.06 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="640 480"/>
-                    <site name="head_right_cam_site" pos="0.05 -0.06 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
-                    <camera name="right_cam" pos="0.05 -0.06 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="640 480"/>
-                    <site name="head_depth_cam_site" pos="0.05 0 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
+                    <!-- RGB Camera -->
+                    <site name="head_rgb_cam_site" pos="0.05 0.0 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
+                    <camera name="rgb_cam" pos="0.05 0.06 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="640 480"/>
+
+                    <!-- Depth Camera -->
+                    <site name="head_depth_cam_site" pos="0.05 0.0 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
                     <camera name="depth_cam" pos="0.05 0 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="640 480"/>
+
                 </body>
             </body>
 

--- a/resources/robots/Booster-T1/instance.xml
+++ b/resources/robots/Booster-T1/instance.xml
@@ -37,6 +37,8 @@
                     <camera name="left_cam" pos="0.05 0.06 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="640 480"/>
                     <site name="head_right_cam_site" pos="0.05 -0.06 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
                     <camera name="right_cam" pos="0.05 -0.06 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="640 480"/>
+                    <site name="head_depth_cam_site" pos="0.05 0 0.0833" size="0.008" rgba="0.1 0.8 0.1 1"/>
+                    <camera name="depth_cam" pos="0.05 0 0.083" quat="-0.5 -0.5 0.5 0.5" fovy="70" resolution="640 480"/>
                 </body>
             </body>
 

--- a/src/SimulationViewport.cpp
+++ b/src/SimulationViewport.cpp
@@ -53,17 +53,13 @@ void SimulationViewport::paintGL() {
         auto robot = RobotManager::instance().getRobots()[i];
 
         std::map<std::string, Sensor*> sensors = robot->getSensors();
-        Camera* leftCamera = dynamic_cast<Camera*>(sensors["rgb_left_camera"]);
-        Camera* rightCamera = dynamic_cast<Camera*>(sensors["rgb_right_camera"]);
+        CameraRGB* rgbCamera = dynamic_cast<CameraRGB*>(sensors["rgb_camera"]);
         CameraDepth* depthCamera = dynamic_cast<CameraDepth*>(sensors["depth_camera"]);
 
-        if (!leftCamera || !rightCamera)
-            continue;
-
-        // Render and capture camera images (save every 60 frames)
-        leftCamera->render();
-        rightCamera->render();
-        depthCamera->render();
+        if (rgbCamera)
+            rgbCamera->render();
+        if (depthCamera)
+            depthCamera->render();
     }
 
     // Restore main viewport scene

--- a/src/SimulationViewport.cpp
+++ b/src/SimulationViewport.cpp
@@ -55,6 +55,7 @@ void SimulationViewport::paintGL() {
         std::map<std::string, Sensor*> sensors = robot->getSensors();
         Camera* leftCamera = dynamic_cast<Camera*>(sensors["rgb_left_camera"]);
         Camera* rightCamera = dynamic_cast<Camera*>(sensors["rgb_right_camera"]);
+        CameraDepth* depthCamera = dynamic_cast<CameraDepth*>(sensors["depth_camera"]);
 
         if (!leftCamera || !rightCamera)
             continue;
@@ -62,6 +63,7 @@ void SimulationViewport::paintGL() {
         // Render and capture camera images (save every 60 frames)
         leftCamera->render();
         rightCamera->render();
+        depthCamera->render();
     }
 
     // Restore main viewport scene


### PR DESCRIPTION
Implementation of depth camera #25. Mujoco doesn't provide a depth sensor but it store depth data which can be similarly to RGB camera. A new Camera have been added in the middle of the two existing cameras.
Below the output of the cameras RGB-Depth-blender

New sensor camera is a paste-and-copy of the existing rgb-camera with modified `mjr_readPixels` to read depth data

<img width="640" height="480" alt="frame_0000" src="https://github.com/user-attachments/assets/95cfb5d3-420b-4421-a1d5-845e39ffda2e" />
<img width="640" height="480" alt="frame_0000_depth" src="https://github.com/user-attachments/assets/cf8397b4-c69c-4384-9c5c-7ee157f73964" />
<img width="1205" height="697" alt="Screenshot from 2026-02-01 11-10-02" src="https://github.com/user-attachments/assets/1e86efae-ac93-4db7-a55c-4674ce0744d7" />
