### PR TITLE
Inizialize robots before communication

### DIFF
--- a/src/AppWindow.cpp
+++ b/src/AppWindow.cpp
@@ -209,8 +209,8 @@ void AppWindow::loadScene(const QString& yaml_file) {
                 Qt::QueuedConnection);
         });
 
+        RobotManager::instance().bindMujoco(mujContext.get());  // memo: this must be run before starting the communications server
         RobotManager::instance().startContainers();
-        RobotManager::instance().bindMujoco(mujContext.get());
 
         // Set initial simulation state (playing when scene is loaded)
         toolsPanel->setSimulationPlaying(true);


### PR DESCRIPTION
Un semplice scambio per fare le cose nell'ordine corretto nel constesto multithread. Fixa il segfault nella scena 5v5.